### PR TITLE
fix misleading render cmd in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ If you want to render with our pre-trained model, you should visit [here](https:
 You can use the following command to render:
 
 ```bash
-python scripts/cicai_render.py --load-config outputs/nvs75fullseq/nsg-vkitti-car-depth-nvs/2023-06-21_135412/config.yml --output-path renders/
+python scripts/cicai_render.py --load-config outputs/nvs75fullseq/nsg-vkitti-car-depth-nvs/2023-06-21_135412/config.yml
 ```
 
 ## Citation


### PR DESCRIPTION
This PR is going to fix a misleading example cmd, or people could waste time generating the whole scene but save nothing.
Both of these are ok:
```
python scripts/cicai_render.py --load-config outputs/clone/nsg-vkitti-car-depth-recon/2023-08-04_153117/config.yml
or
python scripts/cicai_render.py --load-config outputs/clone/nsg-vkitti-car-depth-recon/2023-08-04_153117/config.yml --output-path renders/output.mp4
```
however, the cmd in the readme.md now:
```
python scripts/cicai_render.py --load-config outputs/clone/nsg-vkitti-car-depth-recon/2023-08-04_153117/config.yml --output-path renders/
```
is wrong, and nothing would be saved.

Related to:https://github.com/OPEN-AIR-SUN/mars/issues/26#issuecomment-1667380159