### PR TITLE
Reduce memory demand for object info/ tracklet loading

### DIFF
--- a/mars/data/mars_datamanager.py
+++ b/mars/data/mars_datamanager.py
@@ -89,7 +89,7 @@ class MarsDataManager(VanillaDataManager):  # pylint: disable=abstract-method
             image_idx = int(camera_ray_bundle.camera_indices[0, 0, 0])
             object_rays_info = self.eval_dataset.metadata["obj_info"][image_idx]
 
-            object_rays_info_view = object_rays_info.expand(camera_ray_bundle.shape[0], camera_ray_bundle.shape[0], -1, -1)
+            object_rays_info_view = object_rays_info.expand(camera_ray_bundle.shape[0], camera_ray_bundle.shape[1], -1, -1)
 
             camera_ray_bundle.metadata["object_rays_info"] = object_rays_info_view.reshape(
                 camera_ray_bundle.shape[0], camera_ray_bundle.shape[1], -1

--- a/mars/data/mars_datamanager.py
+++ b/mars/data/mars_datamanager.py
@@ -56,9 +56,11 @@ class MarsDataManager(VanillaDataManager):  # pylint: disable=abstract-method
         ray_bundle = self.train_ray_generator(ray_indices)
 
         c = ray_indices[:, 0]  # camera indices
-        y = ray_indices[:, 1]  # row indices
-        x = ray_indices[:, 2]  # col indices
-        object_rays_info = self.train_dataset.metadata["obj_info"][c, y, x]
+        # y = ray_indices[:, 1]  # row indices
+        # x = ray_indices[:, 2]  # col indices
+
+        # PR: Adjusted to match the new tensor structure
+        object_rays_info = self.train_dataset.metadata["obj_info"][c]
         object_rays_info = object_rays_info.reshape(object_rays_info.shape[0], -1)
         ray_bundle.metadata["object_rays_info"] = object_rays_info.detach()
         return ray_bundle, batch
@@ -72,9 +74,11 @@ class MarsDataManager(VanillaDataManager):  # pylint: disable=abstract-method
         ray_indices = batch["indices"]
         ray_bundle = self.eval_ray_generator(ray_indices)
         c = ray_indices[:, 0]  # camera indices
-        y = ray_indices[:, 1]  # row indices
-        x = ray_indices[:, 2]  # col indices
-        object_rays_info = self.eval_dataset.metadata["obj_info"][c, y, x]
+        # y = ray_indices[:, 1]  # row indices
+        # x = ray_indices[:, 2]  # col indices
+
+        # PR: Adjusted to match the new tensor structure
+        object_rays_info = self.eval_dataset.metadata["obj_info"][c]
         object_rays_info = object_rays_info.reshape(object_rays_info.shape[0], -1)
         ray_bundle.metadata["object_rays_info"] = object_rays_info.detach()
         return ray_bundle, batch
@@ -84,7 +88,14 @@ class MarsDataManager(VanillaDataManager):  # pylint: disable=abstract-method
             assert camera_ray_bundle.camera_indices is not None
             image_idx = int(camera_ray_bundle.camera_indices[0, 0, 0])
             object_rays_info = self.eval_dataset.metadata["obj_info"][image_idx]
-            camera_ray_bundle.metadata["object_rays_info"] = object_rays_info.reshape(
+
+            # PR: Expand tensor here
+            image_width = self.eval_dataset.cameras[image_idx].width
+            image_height = self.eval_dataset.cameras[image_idx].height
+
+            object_rays_info_view = object_rays_info.expand(image_height[0], image_width[0], -1, -1)
+
+            camera_ray_bundle.metadata["object_rays_info"] = object_rays_info_view.reshape(
                 camera_ray_bundle.shape[0], camera_ray_bundle.shape[1], -1
             ).detach()
             return image_idx, camera_ray_bundle, batch

--- a/mars/data/mars_datamanager.py
+++ b/mars/data/mars_datamanager.py
@@ -89,11 +89,7 @@ class MarsDataManager(VanillaDataManager):  # pylint: disable=abstract-method
             image_idx = int(camera_ray_bundle.camera_indices[0, 0, 0])
             object_rays_info = self.eval_dataset.metadata["obj_info"][image_idx]
 
-            # PR: Expand tensor here
-            image_width = self.eval_dataset.cameras[image_idx].width
-            image_height = self.eval_dataset.cameras[image_idx].height
-
-            object_rays_info_view = object_rays_info.expand(image_height[0], image_width[0], -1, -1)
+            object_rays_info_view = object_rays_info.expand(camera_ray_bundle.shape[0], camera_ray_bundle.shape[0], -1, -1)
 
             camera_ray_bundle.metadata["object_rays_info"] = object_rays_info_view.reshape(
                 camera_ray_bundle.shape[0], camera_ray_bundle.shape[1], -1

--- a/mars/data/mars_kitti_dataparser.py
+++ b/mars/data/mars_kitti_dataparser.py
@@ -1227,12 +1227,7 @@ class MarsKittiParser(DataParser):
         obj_nodes_tensor = torch.from_numpy(obj_nodes)
         # if self.config.fast_loading:
         #     obj_nodes_tensor = obj_nodes_tensor.cuda()
-
-        # PR: Removed repeat_interleave lines
-        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_width, dim=2)
-        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_height, dim=2)
-
-        # PR: Added unsqueeze to match dimensions and enable expand later
+        
         obj_nodes_tensor = obj_nodes_tensor.unsqueeze(1).unsqueeze(1)
 
         obj_size = self.max_input_objects * add_input_rows
@@ -1242,13 +1237,7 @@ class MarsKittiParser(DataParser):
 
         # [N, H, W, ro+rd+rgb+obj_nodes*max_obj, 3]
         # with obj_nodes [(x+y+z)*max_obj + (obj_id+is_training+0)*max_obj]
-        obj_nodes_tensor = obj_nodes_tensor.permute([0, 2, 3, 1, 4]).cpu()
-        # obj_nodes = np.stack([obj_nodes[i] for i in i_train], axis=0)  # train images only
         
-        # PR: Removed next line
-        # obj_info = torch.cat([obj_nodes_tensor[i : i + 1] for i in indices], dim=0)
-
-        # PR: Simplified indexing/ filtering
         obj_info = obj_nodes_tensor[indices, ...]
 
         # """

--- a/mars/data/mars_kitti_dataparser.py
+++ b/mars/data/mars_kitti_dataparser.py
@@ -1227,8 +1227,13 @@ class MarsKittiParser(DataParser):
         obj_nodes_tensor = torch.from_numpy(obj_nodes)
         # if self.config.fast_loading:
         #     obj_nodes_tensor = obj_nodes_tensor.cuda()
-        obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_width, dim=2)
-        obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_height, dim=2)
+
+        # PR: Removed repeat_interleave lines
+        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_width, dim=2)
+        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_height, dim=2)
+
+        # PR: Added unsqueeze to match dimensions and enable expand later
+        obj_nodes_tensor = obj_nodes_tensor.unsqueeze(1).unsqueeze(1)
 
         obj_size = self.max_input_objects * add_input_rows
         input_size += obj_size
@@ -1239,7 +1244,12 @@ class MarsKittiParser(DataParser):
         # with obj_nodes [(x+y+z)*max_obj + (obj_id+is_training+0)*max_obj]
         obj_nodes_tensor = obj_nodes_tensor.permute([0, 2, 3, 1, 4]).cpu()
         # obj_nodes = np.stack([obj_nodes[i] for i in i_train], axis=0)  # train images only
-        obj_info = torch.cat([obj_nodes_tensor[i : i + 1] for i in indices], dim=0)
+        
+        # PR: Removed next line
+        # obj_info = torch.cat([obj_nodes_tensor[i : i + 1] for i in indices], dim=0)
+
+        # PR: Simplified indexing/ filtering
+        obj_info = obj_nodes_tensor[indices, ...]
 
         # """
         # obj_info: n_images * image height * image width * (rays_o, rays_d, rgb, add_input_rows * n_max_obj) * 3

--- a/mars/data/mars_vkitti_dataparser.py
+++ b/mars/data/mars_vkitti_dataparser.py
@@ -596,8 +596,13 @@ class MarsVKittiParser(DataParser):
 
         obj_nodes_tensor = torch.from_numpy(obj_nodes)
         # obj_nodes_tensor = torch.from_numpy(obj_nodes).cuda()
-        obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_width, dim=2)
-        obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_height, dim=2)
+
+        # PR: Removed repeat_interleave lines
+        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_width, dim=2)
+        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_height, dim=2)
+
+        # PR: Added unsqueeze to match dimensions and enable expand later
+        obj_nodes_tensor = obj_nodes_tensor.unsqueeze(1).unsqueeze(1)
 
         obj_size = self.max_input_objects * add_input_rows
         input_size += obj_size
@@ -608,7 +613,12 @@ class MarsVKittiParser(DataParser):
         # with obj_nodes [(x+y+z)*max_obj + (obj_id+is_training+0)*max_obj]
         obj_nodes_tensor = obj_nodes_tensor.permute([0, 2, 3, 1, 4]).cpu()
         # obj_nodes = np.stack([obj_nodes[i] for i in i_train], axis=0)  # train images only
-        obj_info = torch.cat([obj_nodes_tensor[i : i + 1] for i in indices], dim=0)
+        
+        # PR: Removed next line
+        # obj_info = torch.cat([obj_nodes_tensor[i : i + 1] for i in indices], dim=0)
+
+        # PR: Simplified indexing/ filtering
+        obj_info = obj_nodes_tensor[indices, ...]
 
         image_filenames = [imgs_name[i] for i in indices]
         instance_filenames = [instance_name[i] for i in indices]

--- a/mars/data/mars_vkitti_dataparser.py
+++ b/mars/data/mars_vkitti_dataparser.py
@@ -597,11 +597,6 @@ class MarsVKittiParser(DataParser):
         obj_nodes_tensor = torch.from_numpy(obj_nodes)
         # obj_nodes_tensor = torch.from_numpy(obj_nodes).cuda()
 
-        # PR: Removed repeat_interleave lines
-        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_width, dim=2)
-        # obj_nodes_tensor = obj_nodes_tensor[:, :, None, ...].repeat_interleave(image_height, dim=2)
-
-        # PR: Added unsqueeze to match dimensions and enable expand later
         obj_nodes_tensor = obj_nodes_tensor.unsqueeze(1).unsqueeze(1)
 
         obj_size = self.max_input_objects * add_input_rows
@@ -611,13 +606,7 @@ class MarsVKittiParser(DataParser):
 
         # [N, H, W, ro+rd+rgb+obj_nodes*max_obj, 3]
         # with obj_nodes [(x+y+z)*max_obj + (obj_id+is_training+0)*max_obj]
-        obj_nodes_tensor = obj_nodes_tensor.permute([0, 2, 3, 1, 4]).cpu()
-        # obj_nodes = np.stack([obj_nodes[i] for i in i_train], axis=0)  # train images only
         
-        # PR: Removed next line
-        # obj_info = torch.cat([obj_nodes_tensor[i : i + 1] for i in indices], dim=0)
-
-        # PR: Simplified indexing/ filtering
         obj_info = obj_nodes_tensor[indices, ...]
 
         image_filenames = [imgs_name[i] for i in indices]

--- a/mars/mars_pipeline.py
+++ b/mars/mars_pipeline.py
@@ -215,15 +215,9 @@ class MarsPipeline(Pipeline):
                 # time this the following line
                 inner_start = time()
 
-                # PR: Expand tensor here
-                image_idx = batch["image_idx"]
+                object_rays_info = self.datamanager.eval_dataset.metadata["obj_info"][batch["image_idx"]]
 
-                object_rays_info = self.datamanager.eval_dataset.metadata["obj_info"][image_idx]
-
-                image_width = self.datamanager.eval_dataset.cameras[image_idx].width
-                image_height = self.datamanager.eval_dataset.cameras[image_idx].height
-
-                object_rays_info_view = object_rays_info.expand(image_height[0], image_width[0], -1, -1)
+                object_rays_info_view = object_rays_info.expand(camera_ray_bundle.shape[0], camera_ray_bundle.shape[1], -1, -1)
 
                 camera_ray_bundle.metadata["object_rays_info"] = object_rays_info_view.reshape(
                     camera_ray_bundle.shape[0], camera_ray_bundle.shape[1], -1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mars-nerfstudio"
-version = "0.3.3post2"
+version = "0.3.4"
 description = "The official code repository for the paper: MARS: An Instance-aware, Modular and Realistic Simulator for Autonomous Driving"
 readme = "README.md"
 license = { text="Apache 2.0" }


### PR DESCRIPTION
Reduced tensor size when loading tracklets/ object information by reducing redundancy initially and only adding it when necessary for evaluation. Testing on KITTI/ VKITTI would be necessary as I'm currently experimenting on the PandaSet dataset. Rendering quality should not be impacted, however, there might be some impact on the training duration, as the tensor has to be expanded when evaluating on full images. 